### PR TITLE
Set proxy_buffer_size to 8k

### DIFF
--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -2,6 +2,7 @@
 location __PATH__/ {
 
   proxy_pass http://127.0.0.1:__PORT_FRONTEND__;
+  proxy_buffer_size 8k;
   proxy_redirect    off;
   proxy_set_header  Host $host;
   proxy_set_header  X-Real-IP $remote_addr;


### PR DESCRIPTION
## Problem

Fixes #12 
The AdventureLog back-end can send an excessively large header and can oversize the nginx default value, which can lead to inaccessible links.

## Solution

Explicitly set `proxy_buffer_size` to 8kB.