### PR TITLE
Admin fix

### DIFF
--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -18,6 +18,7 @@ location /admin/ {
      proxy_pass http://127.0.0.1:8015;
      include proxy_params_no_auth;
      proxy_set_header X-Forwarded-Port  $server_port;
+     proxy_set_header   REMOTE_USER          $http_ynh_user;
 }
 
 location /media/ {

--- a/manifest.toml
+++ b/manifest.toml
@@ -66,7 +66,7 @@ ram.runtime = "50M"
     
     admin.url ="/admin"
     admin.allowed = "admins"
-    admin.show_tile = false
+    admin.show_tile = true
     admin.protected = true
 
     [resources.ports]


### PR DESCRIPTION
See this forum thread : https://forum.yunohost.org/t/cannot-login-to-adventurelog/42270
allows forwarding remote_user header