### PR TITLE
Admin fix

### DIFF
--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -18,6 +18,7 @@ location /admin/ {
      proxy_pass http://127.0.0.1:8015;
      include proxy_params_no_auth;
      proxy_set_header X-Forwarded-Port  $server_port;
+     proxy_set_header   REMOTE_USER          $http_ynh_user;
 }
 
 location /media/ {

--- a/doc/PRE_UGPRADE.d/0.11.0~ynh4.md
+++ b/doc/PRE_UGPRADE.d/0.11.0~ynh4.md
@@ -1,0 +1,1 @@
+This is a package update that fixes the access to the admin interface.

--- a/manifest.toml
+++ b/manifest.toml
@@ -66,7 +66,7 @@ ram.runtime = "50M"
     
     admin.url ="/admin"
     admin.allowed = "admins"
-    admin.show_tile = true
+    admin.show_tile = false
     admin.protected = true
 
     [resources.ports]

--- a/manifest.toml
+++ b/manifest.toml
@@ -6,7 +6,7 @@ id = "adventurelog"
 name = "AdventureLog"
 description.en = "Travel companion for the modern-day explorer."
 
-version = "0.11.0~ynh3"
+version = "0.11.0~ynh4"
 
 maintainers = ["Thovi98"]
 

--- a/manifest.toml
+++ b/manifest.toml
@@ -66,7 +66,7 @@ ram.runtime = "50M"
     
     admin.url ="/admin"
     admin.allowed = "admins"
-    admin.show_tile = false
+    admin.show_tile = true
     admin.protected = true
 
     [resources.ports]


### PR DESCRIPTION
See this forum thread : https://forum.yunohost.org/t/cannot-login-to-adventurelog/42270
allows forwarding remote_user header